### PR TITLE
embrace truth and estimate passed to yardstick functions

### DIFF
--- a/R/multieval.R
+++ b/R/multieval.R
@@ -28,8 +28,8 @@ multieval = function(.dataset , .observed, .predictions, .metrics, value_table =
     purrr::map2(.metrics, .predictions, function(x = .metrics, y = .predictions) {
       
       x(data = .dataset,
-        truth = .dataset[[.observed]],
-        estimate = .dataset[[y]],
+        truth = {{ .observed }},
+        estimate = {{ y }},
         na_rm = TRUE) %>% 
         dplyr::mutate(modelo = y) 
     }) %>% 


### PR DESCRIPTION
We are planning a [yardstick](https://github.com/tidymodels/yardstick) release on the 20th. When doing a revdep check, a bug surfaced in this package.

Some old undesirable behavior, where one was able to pass in `data` AND `truth` and `estimate` as vectors, which is no longer allowed. This is fixed in this PR by [embracing](https://rlang.r-lib.org/reference/embrace-operator.html) the variable names.

This PR should work with the CRAN and dev version of {yardstick} so you should be able to merge and update un CRAN before the 20th with no problems.

Cheers!